### PR TITLE
Minor fixes

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -61,6 +61,7 @@ gh
     program.exclude || null
   )
   .then(contributors => {
+    process.stdout.clearLine();
     if (program.write) {
       writeFile(program.write, JSON.stringify(contributors), 'utf8', () =>
         console.log(`Output written to ${program.write}${EOL}`)

--- a/src/lib/github.js
+++ b/src/lib/github.js
@@ -74,13 +74,14 @@ const getRepoContributors = async (owner, repo) => {
 const getUserData = async id => {
 
   try {
-  let { data } = await octokit.users.getById({ id });
-  return {
-    user: data.login,
-    name: data.name,
-    avatar: data.avatar_url,
-    bio: data.bio,
-  };
+    let { data } = await octokit.users.getById({ id });
+    process.stdout.write(`Getting info for user... ${data.login}           \r`);
+    return {
+      user: data.login,
+      name: data.name,
+      avatar: data.avatar_url,
+      bio: data.bio,
+    };
   } catch (error) {
     console.log(`Request failed with error: ${error.status}`);
     return;


### PR DESCRIPTION
* Explain the default out put as terminal
* Sort the repos before fetching contributors
* Print the total public repos available for the organization before fetcing
* Added try catch for inside getUserData function, right now just logs the error code and returns
* Logs the total count of the users available
* Right now logs the userid to console while fetching the data in a single line... Its a bit hacky right now. Am investigating the proper way to do. Let me know if there is know a better way! 

![consolelog](https://user-images.githubusercontent.com/2767425/39957390-f64e2762-560f-11e8-80ad-559d1f37bf6b.gif)
